### PR TITLE
fix(argv): Fix wrong argv name passing from bin to index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,11 @@ const jest = require('jest')
 const baseConfig = require('./config')
 
 module.exports = function runTest (opts = {}) {
-  const { root, extraArgv, config } = opts
+  const { config } = opts
 
   let argv = ['--config', JSON.stringify({ ...baseConfig, ...config })]
 
-  if (extraArgv) argv = argv.concat(extraArgv)
+  if (opts.argv) argv = argv.concat(opts.argv)
 
-  return jest.run(argv, root)
+  return jest.run(argv)
 }


### PR DESCRIPTION
This commit allow passing argument to jest like `--coverage` like when we write the test command in `package.json`

Exemple:
```json
"coverage", "nuxt-puppeteer-jest --coverage"
```

Or:
```json
"coverage", "node_modules/.bin/nuxt-puppeteer-jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
```

*Note: for commit, I use [conventional commits syntax](https://conventionalcommits.org/)*